### PR TITLE
Add cat meme background to landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ export default function Home() {
     <main
       className="flex min-h-screen flex-col items-center justify-center p-24 bg-cover bg-center bg-no-repeat"
       style={{
-        backgroundImage: "url('https://i.imgflip.com/ahayfe.gif')",
+        backgroundImage: "url('https://i.imgflip.com/ahb5hm.jpg')",
       }}
     >
       <div className="text-6xl font-bold text-white drop-shadow-lg">Dummy</div>


### PR DESCRIPTION
## Summary
- Add a cat meme as the full-screen background image on the landing page
- Update text styling to white with drop shadow for visibility against the background

## Test plan
- [ ] Run `bun dev` and verify the cat meme background displays correctly
- [ ] Confirm the "Dummy" text is visible with the white color and shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)