### PR TITLE
Add stupid Boromir meme background to landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,8 @@
 export default function Home() {
-  return <main className="flex min-h-screen flex-col items-center justify-center p-24">
-    <div className="text-6xl font-bold">Dummy</div>
+  return <main
+    className="flex min-h-screen flex-col items-center justify-center p-24 bg-cover bg-center bg-no-repeat"
+    style={{ backgroundImage: "url('https://i.imgflip.com/1bij.jpg')" }}
+  >
+    <div className="text-6xl font-bold text-white drop-shadow-lg" style={{ textShadow: '2px 2px 4px #000, -2px -2px 4px #000' }}>Dummy</div>
   </main>
 }


### PR DESCRIPTION
### Summary
Adds a classic "One Does Not Simply" Boromir meme as the landing page background because why not. Also added text shadow styling so the "Dummy" title is readable over the meme.

### How to review
- Check `app/page.tsx` - that's the only file changed
- The background image URL points to imgflip's hosted Boromir meme

### Test plan
- [ ] Manual: Run `bun dev` and visit the landing page to witness the glory

### Risk / impact
None. This is purely cosmetic stupidity. Easy rollback by reverting the single commit.

---
🤖 Generated with [Claude Code](https://claude.ai/code)