### PR TITLE
Add stupid Boromir meme background to landing page

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,8 @@
 export default function Home() {
-  return <main className="flex min-h-screen flex-col items-center justify-center p-24">
-    <div className="text-6xl font-bold">Dummy</div>
+  return <main
+    className="flex min-h-screen flex-col items-center justify-center p-24 bg-cover bg-center bg-no-repeat"
+    style={{ backgroundImage: "url('https://i.imgflip.com/1bij.jpg')" }}
+  >
+    <div className="text-6xl font-bold text-white drop-shadow-lg" style={{ textShadow: '2px 2px 4px #000, -2px -2px 4px #000' }}>Dummy</div>
   </main>
 }


### PR DESCRIPTION
## Summary
- Adds a full-screen Boromir meme background image to the landing page
- Applies text shadow styling for readability against the background

## Test plan
- [ ] Open the landing page and verify the stupid background is visible
- [ ] Check that the "Dummy" text is readable with the text shadow

🤖 Generated with [Claude Code](https://claude.com/claude-code)