### PR TITLE
test(deploy): exercise yearn-gha 1P→Vercel CLI sync

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -13,10 +13,9 @@ permissions:
 
 jobs:
   deploy:
-    # TODO: pin to the yearn-gha sha once the Infisical workflow lands
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@spike-infisical
+    # yearn-gha spike-infisical: infisical oidc + vercel remote build
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@db964157cb49f435deff1dca68760c3c9008b993
     with:
-      project-slug: webops-prod-dummy
-      # TODO: fill with the machine identity UUIDs created in Infisical
-      identity-id: ${{ github.event_name == 'pull_request' && '<preview-identity-uuid>' || '<production-identity-uuid>' }}
+      project-slug: dummy-test
+      identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -11,6 +11,8 @@ permissions:
   id-token: write
   pull-requests: write
 
+env:
+  IDENTITY_ID: ${{ secrets.IDENTITY_ID }}
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
@@ -19,4 +21,4 @@ jobs:
       project-slug: dummy-practice
       preview-env-slug: dev
       env-slug: prod
-      identity-id: ${{ secrets.IDENTITY_ID }}
+      identity-id: ${{ env.IDENTITY_ID }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 6c44f799b5fd19a22edd1473f0dc07fa4fb21cbe
+    # yearn-gha fix/vercel-1p-env-sync @ 9b9f8f5b34acd10b311c563c485efe069678aac6
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@6c44f799b5fd19a22edd1473f0dc07fa4fb21cbe
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@9b9f8f5b34acd10b311c563c485efe069678aac6
     with:
-      workflows-ref: 6c44f799b5fd19a22edd1473f0dc07fa4fb21cbe
+      workflows-ref: 9b9f8f5b34acd10b311c563c485efe069678aac6
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -5,6 +5,10 @@ on:
   push:
     branches: [main]
 
+concurrency:
+  group: vercel-deploy-${{ github.ref }}
+  cancel-in-progress: true
+
 permissions:
   contents: read
   deployments: write
@@ -14,10 +18,7 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@10bc1be9dad5562ab7a91ab19285dd89cf938fc0
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@5af200955b947b98f5db62d7294d798efdb56996
     with:
       project-slug: dummy-practice
-      shared-identity-id: ba7ada11-cb47-4e82-9a28-9860c3f5a6ad
-      preview-env-slug: dev
-      env-slug: prod
       identity-id: d677f107-e29c-45d0-8c1e-96279f45ca28

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@96c202fa961a91669ca2e1e3f93b0fc461bf3515
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@4b7a2b4b04b7f1d22a1893c1594ee622bf05d086
     with:
       project-slug: dummy-practice
       preview-env-slug: dev

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@a66af95
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@a66af9571c5472ffcde7866296f77abe77b84d17
     with:
       project-slug: dummy-practice
       preview-env-slug: dev

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,11 +16,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 033d8b7d41c657505e21374d974b6b0ced3258d5
+    # yearn-gha fix/vercel-1p-env-sync @ 4b0320db7006da32c70d5e4368ddec388b28f57e
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@033d8b7d41c657505e21374d974b6b0ced3258d5
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@4b0320db7006da32c70d5e4368ddec388b28f57e
     with:
+      workflows-ref: 4b0320db7006da32c70d5e4368ddec388b28f57e
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@a7ee77ba8fd3c7f0cb64d5dc13cd057e9f984836
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@a66af95
     with:
       project-slug: dummy-practice
       preview-env-slug: dev

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -17,8 +17,9 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@5af200955b947b98f5db62d7294d798efdb56996
+    # yearn-gha spike-infisical @ 2b1600ecbdc7ae55daf59be268d81239bd6f7ecb — default mode (app prod:/deploy-config)
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@2b1600ecbdc7ae55daf59be268d81239bd6f7ecb
     with:
       project-slug: dummy-practice
+      # single preview identity for harness; production identity not wired yet
       identity-id: d677f107-e29c-45d0-8c1e-96279f45ca28

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,9 +14,9 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@a66af9571c5472ffcde7866296f77abe77b84d17
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@96c202fa961a91669ca2e1e3f93b0fc461bf3515
     with:
       project-slug: dummy-practice
       preview-env-slug: dev
       env-slug: prod
-      identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3
+      identity-id: ${{ secrets.IDENTITY_ID }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -8,20 +8,15 @@ on:
 permissions:
   contents: read
   deployments: write
+  id-token: write
   pull-requests: write
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 86d2fd001f5c6692b20e66339863668a7366e5e9
-    # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
-    # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@86d2fd001f5c6692b20e66339863668a7366e5e9
+    # TODO: pin to the yearn-gha sha once the Infisical workflow lands
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@spike-infisical
     with:
-      workflows-ref: 86d2fd001f5c6692b20e66339863668a7366e5e9
-      vault: webops-prod-dummy
+      project-slug: webops-prod-dummy
+      # TODO: fill with the machine identity UUIDs created in Infisical
+      identity-id: ${{ github.event_name == 'pull_request' && '<preview-identity-uuid>' || '<production-identity-uuid>' }}
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
-      secrets: |
-        SECRET_TEXT=dummy/SECRET_TEXT
-        NEXT_PUBLIC_TEXT=dummy/NEXT_PUBLIC_TEXT
-    secrets:
-      OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -20,4 +20,4 @@ jobs:
       shared-identity-id: ba7ada11-cb47-4e82-9a28-9860c3f5a6ad
       preview-env-slug: dev
       env-slug: prod
-      identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3
+      identity-id: d677f107-e29c-45d0-8c1e-96279f45ca28

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 54c6ae6a1fa958dac013df91f1f3b337a7564226
+    # yearn-gha fix/vercel-1p-env-sync @ 86d2fd001f5c6692b20e66339863668a7366e5e9
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@54c6ae6a1fa958dac013df91f1f3b337a7564226
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@86d2fd001f5c6692b20e66339863668a7366e5e9
     with:
-      workflows-ref: 54c6ae6a1fa958dac013df91f1f3b337a7564226
+      workflows-ref: 86d2fd001f5c6692b20e66339863668a7366e5e9
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,9 +16,9 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 5fc61270a5870d33a62e55bfedf054a9e833bb29
+    # yearn-gha fix/vercel-1p-env-sync @ 97e6703a0935f7a9d51ba49f8d230688e05041e3
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@5fc61270a5870d33a62e55bfedf054a9e833bb29
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@97e6703a0935f7a9d51ba49f8d230688e05041e3
     with:
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -11,8 +11,6 @@ permissions:
   id-token: write
   pull-requests: write
 
-env:
-  IDENTITY_ID: ${{ secrets.IDENTITY_ID }}
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
@@ -21,4 +19,4 @@ jobs:
       project-slug: dummy-practice
       preview-env-slug: dev
       env-slug: prod
-      identity-id: ${{ env.IDENTITY_ID }}
+      identity-id: ${{ secrets.IDENTITY_ID }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 1135f3fb707d8ef37f9b1bf3ec8b7895927a622e
+    # yearn-gha fix/vercel-1p-env-sync @ 2619682a8517071e129dc5b83877f77b8d3b2b0d
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@1135f3fb707d8ef37f9b1bf3ec8b7895927a622e
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@2619682a8517071e129dc5b83877f77b8d3b2b0d
     with:
-      workflows-ref: 1135f3fb707d8ef37f9b1bf3ec8b7895927a622e
+      workflows-ref: 2619682a8517071e129dc5b83877f77b8d3b2b0d
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 2619682a8517071e129dc5b83877f77b8d3b2b0d
+    # yearn-gha fix/vercel-1p-env-sync @ e786aff8d6c55eb31a1b57568e97d2f38947c67e
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@2619682a8517071e129dc5b83877f77b8d3b2b0d
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@e786aff8d6c55eb31a1b57568e97d2f38947c67e
     with:
-      workflows-ref: 2619682a8517071e129dc5b83877f77b8d3b2b0d
+      workflows-ref: e786aff8d6c55eb31a1b57568e97d2f38947c67e
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,5 +16,7 @@ jobs:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
     uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@8ce7aba9d71a00f0fe246e5e7270f94be78f3085
     with:
-      project-slug: dummy-test-be7p
+      project-slug: dummy-practice
+      preview-env-slug: dev
+      env-slug: prod
       identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 17de1e6fb5a1a7d853757964d15aa2d4ac20994f
+    # yearn-gha fix/vercel-1p-env-sync @ 6c44f799b5fd19a22edd1473f0dc07fa4fb21cbe
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@17de1e6fb5a1a7d853757964d15aa2d4ac20994f
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@6c44f799b5fd19a22edd1473f0dc07fa4fb21cbe
     with:
-      workflows-ref: 17de1e6fb5a1a7d853757964d15aa2d4ac20994f
+      workflows-ref: 6c44f799b5fd19a22edd1473f0dc07fa4fb21cbe
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@6c1a236162e11d1e2a38d6ab8a0830ef944bf1e6
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@10bc1be9dad5562ab7a91ab19285dd89cf938fc0
     with:
       project-slug: dummy-practice
       shared-identity-id: ba7ada11-cb47-4e82-9a28-9860c3f5a6ad

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,7 +16,9 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@711efc3dc97f65bbf6d6045d593732a935171e32
+    # yearn-gha fix/vercel-1p-env-sync @ 5fc61270a5870d33a62e55bfedf054a9e833bb29
+    # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@5fc61270a5870d33a62e55bfedf054a9e833bb29
     with:
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -19,4 +19,4 @@ jobs:
       project-slug: dummy-practice
       preview-env-slug: dev
       env-slug: prod
-      identity-id: ${{ secrets.IDENTITY_ID }}
+      identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 4b0320db7006da32c70d5e4368ddec388b28f57e
+    # yearn-gha fix/vercel-1p-env-sync @ 17de1e6fb5a1a7d853757964d15aa2d4ac20994f
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@4b0320db7006da32c70d5e4368ddec388b28f57e
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@17de1e6fb5a1a7d853757964d15aa2d4ac20994f
     with:
-      workflows-ref: 4b0320db7006da32c70d5e4368ddec388b28f57e
+      workflows-ref: 17de1e6fb5a1a7d853757964d15aa2d4ac20994f
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,9 +16,10 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 97e6703a0935f7a9d51ba49f8d230688e05041e3
-    # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@97e6703a0935f7a9d51ba49f8d230688e05041e3
+    # yearn-gha fix/vercel-1p-env-sync @ 033d8b7d41c657505e21374d974b6b0ced3258d5
+    # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
+    # github deployment record + pr deployment-url comment
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@033d8b7d41c657505e21374d974b6b0ced3258d5
     with:
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 65f00d71c251fcecac84c36c05d34ed1c2085597
+    # yearn-gha fix/vercel-1p-env-sync @ 54c6ae6a1fa958dac013df91f1f3b337a7564226
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@65f00d71c251fcecac84c36c05d34ed1c2085597
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@54c6ae6a1fa958dac013df91f1f3b337a7564226
     with:
-      workflows-ref: 65f00d71c251fcecac84c36c05d34ed1c2085597
+      workflows-ref: 54c6ae6a1fa958dac013df91f1f3b337a7564226
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ 9b9f8f5b34acd10b311c563c485efe069678aac6
+    # yearn-gha fix/vercel-1p-env-sync @ d87bb75ae701ba68e0d4128a4f98fbbd835e7bec
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@9b9f8f5b34acd10b311c563c485efe069678aac6
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@d87bb75ae701ba68e0d4128a4f98fbbd835e7bec
     with:
-      workflows-ref: 9b9f8f5b34acd10b311c563c485efe069678aac6
+      workflows-ref: d87bb75ae701ba68e0d4128a4f98fbbd835e7bec
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,9 +14,10 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@4b7a2b4b04b7f1d22a1893c1594ee622bf05d086
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@6c1a236162e11d1e2a38d6ab8a0830ef944bf1e6
     with:
       project-slug: dummy-practice
+      shared-identity-id: ba7ada11-cb47-4e82-9a28-9860c3f5a6ad
       preview-env-slug: dev
       env-slug: prod
       identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ d87bb75ae701ba68e0d4128a4f98fbbd835e7bec
+    # yearn-gha fix/vercel-1p-env-sync @ 1135f3fb707d8ef37f9b1bf3ec8b7895927a622e
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@d87bb75ae701ba68e0d4128a4f98fbbd835e7bec
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@1135f3fb707d8ef37f9b1bf3ec8b7895927a622e
     with:
-      workflows-ref: d87bb75ae701ba68e0d4128a4f98fbbd835e7bec
+      workflows-ref: 1135f3fb707d8ef37f9b1bf3ec8b7895927a622e
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -16,6 +16,6 @@ jobs:
     # yearn-gha spike-infisical: infisical oidc + vercel remote build
     uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@db964157cb49f435deff1dca68760c3c9008b993
     with:
-      project-slug: dummy-test
+      project-slug: dummy-test-be7p
       identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -22,5 +22,6 @@ jobs:
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |
         SECRET_TEXT=dummy/SECRET_TEXT
+        NEXT_PUBLIC_TEXT=dummy/NEXT_PUBLIC_TEXT
     secrets:
       OP_SERVICE_ACCOUNT_TOKEN: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -13,9 +13,8 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha spike-infisical: infisical oidc + vercel remote build
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@db964157cb49f435deff1dca68760c3c9008b993
+    # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@8ce7aba9d71a00f0fe246e5e7270f94be78f3085
     with:
       project-slug: dummy-test-be7p
       identity-id: 4a214b11-b34b-4e2e-8688-b1e56787b1a3
-      environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -5,10 +5,6 @@ on:
   push:
     branches: [main]
 
-concurrency:
-  group: vercel-deploy-${{ github.ref }}
-  cancel-in-progress: true
-
 permissions:
   contents: read
   deployments: write

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -12,12 +12,12 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha fix/vercel-1p-env-sync @ e786aff8d6c55eb31a1b57568e97d2f38947c67e
+    # yearn-gha fix/vercel-1p-env-sync @ 65f00d71c251fcecac84c36c05d34ed1c2085597
     # 1P → vercel env --sensitive, pure CLI pull/build/deploy --prebuilt,
     # github deployment record + pr deployment-url comment
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@e786aff8d6c55eb31a1b57568e97d2f38947c67e
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@65f00d71c251fcecac84c36c05d34ed1c2085597
     with:
-      workflows-ref: e786aff8d6c55eb31a1b57568e97d2f38947c67e
+      workflows-ref: 65f00d71c251fcecac84c36c05d34ed1c2085597
       vault: webops-prod-dummy
       environment: ${{ github.event_name == 'pull_request' && 'preview' || 'production' }}
       secrets: |

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -14,7 +14,7 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical: shared+app two-fetch, env derived from event
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@8ce7aba9d71a00f0fe246e5e7270f94be78f3085
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@a7ee77ba8fd3c7f0cb64d5dc13cd057e9f984836
     with:
       project-slug: dummy-practice
       preview-env-slug: dev

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -18,7 +18,7 @@ permissions:
 jobs:
   deploy:
     # yearn-gha spike-infisical @ 2b1600ecbdc7ae55daf59be268d81239bd6f7ecb — default mode (app prod:/deploy-config)
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@2b1600ecbdc7ae55daf59be268d81239bd6f7ecb
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@96e9ba35773773d460580a7a6860e9f361b734be
     with:
       project-slug: dummy-practice
       # single preview identity for harness; production identity not wired yet

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,6 +4,7 @@ export default function Home() {
   return (
     <main className="relative min-h-screen flex flex-col items-center justify-center overflow-hidden bg-dark">
       <p>{secretText}</p>
+      <p>{process.env.NEXT_PUBLIC_TEXT}</p>
       {/* Grid overlay */}
       <div className="absolute inset-0 grid-overlay" />
 


### PR DESCRIPTION
## Summary

Test harness for yearn-gha `spike-infisical` @ `10bc1be9dad5562ab7a91ab19285dd89cf938fc0`.

Pins the reusable workflow that:
1. Loads secrets from Infisical (shared + app identity)
2. Syncs them with `vercel env add --sensitive --force` (stdin)
3. Deploys via pure CLI: `pull → build → deploy --prebuilt`

## Secrets

- Vault / shared identity: `ba7ada11-cb47-4e82-9a28-9860c3f5a6ad`
- App identity: `4a214b11-b34b-4e2e-8688-b1e56787b1a3`
- preview-env-slug: `dev`, env-slug: `prod`

## Verify

- [ ] Workflow run succeeds on this PR (preview target)
- [ ] Secrets appear as sensitive env vars on the Vercel project (preview)
- [ ] Deployment URL is commented on the PR / GitHub Deployment created
- [ ] No next.config env inlining (this app already has empty `next.config.mjs`)

Depends on: yearn/yearn-gha@spike-infisical (`10bc1be`)