### PR TITLE
ci: pin yearn-gha Doppler deploy workflow

### DIFF
--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -17,9 +17,7 @@ permissions:
 
 jobs:
   deploy:
-    # yearn-gha spike-infisical @ 2b1600ecbdc7ae55daf59be268d81239bd6f7ecb — default mode (app prod:/deploy-config)
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@96e9ba35773773d460580a7a6860e9f361b734be
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@53ac56e5abfa19e291975fa45c076a01f128d06e
     with:
-      project-slug: dummy-practice
-      # single preview identity for harness; production identity not wired yet
-      identity-id: d677f107-e29c-45d0-8c1e-96279f45ca28
+      project: dummy-practice
+      identity-id: 15ea1d36-986f-46de-815e-e27cc7fc5566

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@53ac56e5abfa19e291975fa45c076a01f128d06e
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@4f8fabb520efa21678d8cafc6808ad67b576a576
     with:
       project: dummy-practice
       identity-id: 15ea1d36-986f-46de-815e-e27cc7fc5566

--- a/.github/workflows/vercel-deploy.yml
+++ b/.github/workflows/vercel-deploy.yml
@@ -17,7 +17,7 @@ permissions:
 
 jobs:
   deploy:
-    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@4f8fabb520efa21678d8cafc6808ad67b576a576
+    uses: yearn/yearn-gha/.github/workflows/vercel-deploy.yml@9701cd661a98fda358bb7b273b2baab97f12dea2
     with:
       project: dummy-practice
-      identity-id: 15ea1d36-986f-46de-815e-e27cc7fc5566
+      identity-id: ${{ github.event_name == 'pull_request' && vars.DOPPLER_PREVIEW_IDENTITY_ID || vars.DOPPLER_PRODUCTION_IDENTITY_ID }}


### PR DESCRIPTION
## Summary

Retarget the dummy Vercel deploy at yearn-gha main `9701cd6` (Doppler OIDC). The caller now passes `project` and selects the Doppler service-account identity from repo vars by event: preview on pull_request, production on push to main.

## Changes

- `uses` SHA: `96e9ba3` (Infisical spike) → `9701cd661a98fda358bb7b273b2baab97f12dea2` (yearn-gha main)
- `project-slug` → `project: dummy-practice`
- `identity-id`: `vars.DOPPLER_PREVIEW_IDENTITY_ID` on pull_request, `vars.DOPPLER_PRODUCTION_IDENTITY_ID` otherwise

## Testing

On this PR: Deploy to Vercel should fetch `deploy-configs` with the preview identity and post a preview URL.

Production identity is only used on push to main. Confirm both repo vars exist before merge.
