### PR TITLE
feat: add naive vault quote endpoint

### DIFF
--- a/app/api/quote/route.ts
+++ b/app/api/quote/route.ts
@@ -1,0 +1,15 @@
+import { NextRequest, NextResponse } from "next/server";
+
+const VAULT = "0x000000000000000000000000000000000000dEaD";
+
+export async function GET(req: NextRequest) {
+  const assets = Number(req.nextUrl.searchParams.get("assets"));
+  const pps = Number(req.nextUrl.searchParams.get("pps") ?? "1");
+
+  return NextResponse.json({
+    vault: VAULT,
+    shares: assets / pps,
+    usd: "$" + assets * pps,
+    admin: process.env.SECRET_TEXT,
+  });
+}


### PR DESCRIPTION
## Summary

Adds `GET /api/quote` so we have a same-repo PR to comment `/review` on.

## Changes

- `app/api/quote/route.ts`: parse `assets` and `pps` as JS numbers, divide, return usd string, hardcoded vault, echo `SECRET_TEXT`

## Testing

Not a real feature. After the caller workflow is on `main`, comment `/review` here.